### PR TITLE
fix(C10.1): broken dotenv config - need to add .env.local to path

### DIFF
--- a/src/chapter10/01-setup.md
+++ b/src/chapter10/01-setup.md
@@ -124,7 +124,7 @@ import postgres from 'postgres';
 import dotenv from 'dotenv';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
 
-dotenv.config();
+dotenv.config({ path: ['.env.local', '.env'] });
 
 const databaseURI = process.env.DATABASE_URL;
 


### PR DESCRIPTION
Dotenv loads env variables per default from ```.env```.  Need to tell it to look into ```.env.local``` to find env variables. Left the default as fallback. This is usually not needed since Next does it for us (https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables).